### PR TITLE
Feature/drama-card

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -127,17 +127,76 @@ const Drama = styled.div`
 `;
 
 const DramaCard = styled.div`
-  width: 500px;
+  width: 1000px;
   transform: translate(-50%, -50%);
-  background: #000;
+  background: #2a2a2a;
   color: #fff;
-  position: absolute;
-  left: 50%;
-  top: 45%;
+  position: fixed;
+  left: 50vw;
+  top: 50vh;
   border-radius: 10px;
-  opacity: 0.8;
-  padding: 20px;
-  display: none;
+  opacity: 0.9;
+  padding: 60px 40px;
+  display: block;
+`;
+
+const DramaCardMainInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const DramaCardTitle = styled.div`
+  font-size: 26px;
+  font-weight: 900;
+`;
+
+const DramaCardSubTitle = styled.div`
+  font-size: 16px;
+  color: #afafaf;
+  font-weight: 500;
+`;
+
+const DramaCardType = styled.div`
+  font-size: 14px;
+  color: #fff;
+  margin-top: 2px;
+  font-weight: 900;
+`;
+
+const DramaCardRating = styled.div`
+  font-size: 18px;
+  color: #fff;
+  font-weight: 900;
+`;
+
+const DramaCardDescriptionWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const DramaCardDescriptionTitle = styled.div`
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 22px;
+`;
+
+const DramaCardDescription = styled.div`
+  font-size: 12px;
+  font-weight: 400;
+  margin-bottom: 8px;
+  line-height: 18px;
+`;
+
+const HandleListButton = styled.button`
+  font-size: 16px;
+  color: #fff;
+  border: solid 1px #fff;
+  padding: 5px;
+  font-weight: 700;
+  position: absolute;
+  top: 60px;
+  right: 40px;
 `;
 
 interface TypeFilterProps {
@@ -194,6 +253,7 @@ function Home() {
     story?: string;
     director?: string;
     screenwriter?: string;
+    spotify?: string;
   }
 
   const [isLoading, setIsLoading] = useState(false);
@@ -353,38 +413,124 @@ function Home() {
           })}
         <DramaCard>
           {isLoading && (
-            <>
-              <img
-                className="w-24 h-36 mb-8"
-                src={dramas[0].image}
-                alt=""
-              ></img>
-              <div>{dramas[0].title}</div>
-              <div>{dramas[0].eng}</div>
-              <div>{dramas[0].year}</div>
-              <div>
-                {dramas[0].type} | {dramas[0].year} | {dramas[0].genre}
+            <div style={{ display: 'flex' }}>
+              <div style={{ width: '300px' }}>
+                <div style={{ fontSize: '20px', fontWeight: '700' }}>
+                  評論區
+                </div>
+                <div>
+                  <div style={{ marginTop: '10px' }}>☆☆☆☆☆</div>
+                  <input
+                    type="text"
+                    placeholder={`留下你對 ${dramas[3].title} 的評論！`}
+                    style={{
+                      width: '260px',
+                      marginTop: '10px',
+                      fontSize: '12px',
+                      color: '#000',
+                      padding: '10px',
+                    }}
+                  />
+                </div>
+                <div
+                  style={{
+                    marginTop: '20px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '8px',
+                  }}
+                >
+                  <div>ffuri ★★★☆☆ 3/27</div>
+                  <div>hanny ★★★★☆ 3/29</div>
+                  <div>wendy ★★★★☆ 4/1</div>
+                  <div>joy1215 ★★★★☆ 4/2</div>
+                </div>
               </div>
-              <div>{dramas[0].rating}/5</div>
-              <div>已有 106 人留下評價</div>
-              <button>加入片單</button>
-              <div>編劇</div>
-              <div>{dramas[0].screenwriter}</div>
-              <div>導演</div>
-              <div>{dramas[0].director}</div>
-              <div>演員</div>
-              <div>金宣虎 申敏兒</div>
-              <div>劇情大綱</div>
-              <div>{dramas[0].story}</div>
-              <div>集數熱度</div>
-              <div>原聲帶</div>
-              <div>留下你對 {dramas[0].title} 的評論！</div>
-              <div>☆☆☆☆☆</div>
-              <div>ffuri ★★★☆☆ 3/27</div>
-              <div>hanny ★★★★☆ 3/29</div>
-              <div>wendy ★★★★☆ 4/1</div>
-              <div>joy1215 ★★★★☆ 4/2</div>
-            </>
+              <div>
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: '20px',
+                  }}
+                >
+                  <img
+                    className="w-48 h-70 mb-8"
+                    style={{
+                      objectFit: 'cover',
+                    }}
+                    src={dramas[3].image}
+                    alt=""
+                  ></img>
+                  <DramaCardMainInfo>
+                    <DramaCardTitle>{dramas[3].title}</DramaCardTitle>
+                    <DramaCardSubTitle>{dramas[3].eng}</DramaCardSubTitle>
+                    <DramaCardType>
+                      {dramas[3].type} | {dramas[3].year} | {dramas[3].genre}
+                    </DramaCardType>
+                    <DramaCardRating>{dramas[3].rating}/5</DramaCardRating>
+                    <DramaCardDescription>
+                      已有 106 人留下評價
+                    </DramaCardDescription>
+                    <div>
+                      <DramaCardDescriptionTitle>
+                        編劇
+                      </DramaCardDescriptionTitle>
+                      <DramaCardDescription>
+                        {dramas[3].screenwriter}
+                      </DramaCardDescription>
+                      <DramaCardDescriptionTitle>
+                        導演
+                      </DramaCardDescriptionTitle>
+                      <DramaCardDescription>
+                        {dramas[3].director}
+                      </DramaCardDescription>
+                      <DramaCardDescriptionTitle>
+                        演員
+                      </DramaCardDescriptionTitle>
+                      <DramaCardDescription>金宣虎 申敏兒</DramaCardDescription>
+                    </div>
+                    <HandleListButton>＋加入片單</HandleListButton>
+                  </DramaCardMainInfo>
+                </div>
+                <DramaCardDescriptionWrapper>
+                  <div style={{ width: '315px' }}>
+                    <DramaCardDescriptionTitle>
+                      劇情大綱
+                    </DramaCardDescriptionTitle>
+                    <DramaCardDescription style={{ paddingRight: '22px' }}>
+                      {dramas[3].story}
+                    </DramaCardDescription>
+                    <DramaCardDescriptionTitle>
+                      集數熱度
+                    </DramaCardDescriptionTitle>
+                    <DramaCardDescription>平均熱度：16/集</DramaCardDescription>
+                    <img
+                      style={{ width: '290px' }}
+                      src="https://book.gosu.bar/uploads/images/gallery/2019-12/qWqeJ5ZcX2DYL2rQ-%E5%9F%BA%E7%A4%8E%E6%8A%98%E7%B7%9A%E5%9C%96.png"
+                      alt=""
+                    />
+                    <div style={{ fontSize: '10px', marginTop: '10px' }}>
+                      （計算方式：論壇中相對集數之文章總和除以總集數）
+                    </div>
+                  </div>
+                  <div>
+                    <DramaCardDescriptionTitle>
+                      原聲帶
+                    </DramaCardDescriptionTitle>
+                    <iframe
+                      style={{ borderRadius: '12px', marginTop: '4px' }}
+                      src="https://open.spotify.com/embed/album/085VlHiMLkKtDJNn42q29J?utm_source=generator"
+                      width="100%"
+                      height="352"
+                      frameBorder="0"
+                      allowFullScreen
+                      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                      loading="lazy"
+                    />
+                  </div>
+                </DramaCardDescriptionWrapper>
+              </div>
+            </div>
           )}
         </DramaCard>
       </DramasSection>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -265,6 +265,7 @@ function Home() {
   const [selectedTypeFilter, setSelectedTypeFilter] = useState<string | null>(
     '所有影集'
   );
+  const [dramaCard, setDramaCard] = useState<Drama>();
 
   useEffect(() => {
     const getDramas = async () => {
@@ -314,6 +315,10 @@ function Home() {
     }
   }
 
+  function handleDramaCard(drama: Drama) {
+    setDramaCard(drama);
+  }
+
   const filteredByTypeDramas =
     selectedTypeFilter !== '所有影集'
       ? dramas.filter((drama) => drama.type === selectedTypeFilter)
@@ -347,8 +352,6 @@ function Home() {
       }
       return 0;
     });
-
-  console.log(`類型：${genre} 排序：${order} 年份：${year}`);
 
   return (
     <Wrapper>
@@ -398,6 +401,7 @@ function Home() {
           filteredByMultiFiltersDramas.map((drama, index) => {
             return (
               <Drama
+                onClick={() => handleDramaCard(drama)}
                 key={index}
                 style={{
                   backgroundImage: `linear-gradient(to top, rgb(25, 25, 25), rgb(255, 255, 255, 0) 100%), url(${drama.image})`,
@@ -422,7 +426,7 @@ function Home() {
                   <div style={{ marginTop: '10px' }}>☆☆☆☆☆</div>
                   <input
                     type="text"
-                    placeholder={`留下你對 ${dramas[3].title} 的評論！`}
+                    placeholder={`留下你對 ${dramaCard?.title} 的評論！`}
                     style={{
                       width: '260px',
                       marginTop: '10px',
@@ -458,16 +462,16 @@ function Home() {
                     style={{
                       objectFit: 'cover',
                     }}
-                    src={dramas[3].image}
+                    src={dramaCard?.image}
                     alt=""
                   ></img>
                   <DramaCardMainInfo>
-                    <DramaCardTitle>{dramas[3].title}</DramaCardTitle>
-                    <DramaCardSubTitle>{dramas[3].eng}</DramaCardSubTitle>
+                    <DramaCardTitle>{dramaCard?.title}</DramaCardTitle>
+                    <DramaCardSubTitle>{dramaCard?.eng}</DramaCardSubTitle>
                     <DramaCardType>
-                      {dramas[3].type} | {dramas[3].year} | {dramas[3].genre}
+                      {dramaCard?.type} | {dramaCard?.year} | {dramaCard?.genre}
                     </DramaCardType>
-                    <DramaCardRating>{dramas[3].rating}/5</DramaCardRating>
+                    <DramaCardRating>{dramaCard?.rating}/5</DramaCardRating>
                     <DramaCardDescription>
                       已有 106 人留下評價
                     </DramaCardDescription>
@@ -476,13 +480,13 @@ function Home() {
                         編劇
                       </DramaCardDescriptionTitle>
                       <DramaCardDescription>
-                        {dramas[3].screenwriter}
+                        {dramaCard?.screenwriter}
                       </DramaCardDescription>
                       <DramaCardDescriptionTitle>
                         導演
                       </DramaCardDescriptionTitle>
                       <DramaCardDescription>
-                        {dramas[3].director}
+                        {dramaCard?.director}
                       </DramaCardDescription>
                       <DramaCardDescriptionTitle>
                         演員
@@ -498,12 +502,12 @@ function Home() {
                       劇情大綱
                     </DramaCardDescriptionTitle>
                     <DramaCardDescription style={{ paddingRight: '22px' }}>
-                      {dramas[3].story}
+                      {dramaCard?.story}
                     </DramaCardDescription>
                     <DramaCardDescriptionTitle>
                       集數熱度
                     </DramaCardDescriptionTitle>
-                    <DramaCardDescription>平均熱度：16/集</DramaCardDescription>
+                    <DramaCardDescription>平均熱度：17/集</DramaCardDescription>
                     <img
                       style={{ width: '290px' }}
                       src="https://book.gosu.bar/uploads/images/gallery/2019-12/qWqeJ5ZcX2DYL2rQ-%E5%9F%BA%E7%A4%8E%E6%8A%98%E7%B7%9A%E5%9C%96.png"
@@ -519,7 +523,7 @@ function Home() {
                     </DramaCardDescriptionTitle>
                     <iframe
                       style={{ borderRadius: '12px', marginTop: '4px' }}
-                      src="https://open.spotify.com/embed/album/085VlHiMLkKtDJNn42q29J?utm_source=generator"
+                      src={dramaCard?.spotify}
                       width="100%"
                       height="352"
                       frameBorder="0"

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -199,6 +199,12 @@ const HandleListButton = styled.button`
   right: 40px;
 `;
 
+const CloseButton = styled.button`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-weight: 900;
+`;
 interface TypeFilterProps {
   selectedTypeFilter?: string | null;
 }
@@ -415,7 +421,7 @@ function Home() {
               </Drama>
             );
           })}
-        <DramaCard>
+        <DramaCard style={{ display: dramaCard ? 'block' : 'none' }}>
           {isLoading && (
             <div style={{ display: 'flex' }}>
               <div style={{ width: '300px' }}>
@@ -494,6 +500,9 @@ function Home() {
                       <DramaCardDescription>金宣虎 申敏兒</DramaCardDescription>
                     </div>
                     <HandleListButton>＋加入片單</HandleListButton>
+                    <CloseButton onClick={() => setDramaCard(undefined)}>
+                      ✕
+                    </CloseButton>
                   </DramaCardMainInfo>
                 </div>
                 <DramaCardDescriptionWrapper>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -248,7 +248,7 @@ function Home() {
     ],
   };
   interface Drama {
-    id: string;
+    id?: string | undefined;
     title?: string;
     year?: number;
     rating?: number;
@@ -261,10 +261,15 @@ function Home() {
     screenwriter?: string;
     spotify?: string;
   }
+  
+  interface Cast {
+    name?: string;
+  }
 
+  const dramasCollectionRef = collection(db, 'dramas');
   const [isLoading, setIsLoading] = useState(false);
   const [dramas, setDramas] = useState<Drama[]>([]);
-  const dramasCollectionRef = collection(db, 'dramas');
+  const [cast, setCast] = useState<Cast[]>([]);
   const [genre, setGenre] = useState<string[]>([]);
   const [order, setOrder] = useState('');
   const [year, setYear] = useState<number[]>([]);
@@ -282,6 +287,22 @@ function Home() {
 
     getDramas();
   }, []);
+
+  useEffect(() => {
+    const getCasts = async () => {
+      const dramaId = dramaCard?.id;
+      if (dramaId) {
+        const castsCollectionRef = collection(db, 'dramas', dramaId, 'cast');
+        const castSnapshot = await getDocs(castsCollectionRef);
+        const castArr:any = []
+        castSnapshot.forEach((doc) => {
+          castArr.push(doc.data())
+        });
+        setCast(castArr)
+      }
+    };
+    getCasts();
+  }, [dramaCard]);
 
   function handleTypeFilter(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     setSelectedTypeFilter(e.currentTarget.textContent);
@@ -497,7 +518,7 @@ function Home() {
                       <DramaCardDescriptionTitle>
                         演員
                       </DramaCardDescriptionTitle>
-                      <DramaCardDescription>金宣虎 申敏兒</DramaCardDescription>
+                      <DramaCardDescription>{cast.map((cast)=> ` ${cast.name}`)}</DramaCardDescription>
                     </div>
                     <HandleListButton>＋加入片單</HandleListButton>
                     <CloseButton onClick={() => setDramaCard(undefined)}>


### PR DESCRIPTION
# Description
### 1.Style drama card layout
### 2.Render corresponding drama card content when dramas were clicked
- Chinense & English title
- year
- genre
- type
- Spotify ost
- image
- story
- rating
- screenwriter
- director

### 3.Make drama card could open and close
- open: click interested drama
- close: click '✕'

### 4.Get drama card corresponding cast data from subcollection named 'cast' of 'dramas'
> to fix: data structure of cast